### PR TITLE
sip:request: add content type

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -14,6 +14,7 @@
     "properties": {
       "id": "string",
       "method": "string",
+      "contentType": "string",
       "body": "string",
       "headers": "object",
       "actionHook": "object|string"


### PR DESCRIPTION
Content type is required if body is supplied in request