### PR TITLE
feat/859: Added generative, long-form to engine enum

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -557,7 +557,7 @@
       "fallbackVoice": "string|object",
       "engine": {
         "type": "string",
-        "enum": ["standard", "neural"]
+        "enum": ["standard", "neural", "generative", "long-form"]
       },
       "gender": {
         "type": "string",


### PR DESCRIPTION
https://github.com/jambonz/jambonz-feature-server/issues/859

Added generative, long-form to engine enum, currently only standard and neural is supported