### PR TITLE
add dial.exitMediaPath to indicate we want to be only in the signalin…

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -273,6 +273,7 @@
       "dtmfHook": "object|string",
       "headers": "object",
       "anchorMedia": "boolean",
+      "exitMediaPath": "boolean",
       "boostAudioSignal": "number|string",
       "listen": "#listen",
       "target": ["#target"],


### PR DESCRIPTION
…g path for this bridged call; media is completely released from all jambonz components