### PR TITLE
make llm.model optional

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -451,7 +451,6 @@
     },
     "required": [
       "vendor",
-      "model",
       "auth",
       "llmOptions"
     ]


### PR DESCRIPTION
model is not required for llm providers, for elevenlabs you cannot set it in the API it must be created in the dashboard with the agent_id.
Where the vendor does use this param we have a default in the task code, apart from deepgram, (I'l add a PR for default there)